### PR TITLE
Fix compatibility with TeXlive 2016 fontspec

### DIFF
--- a/style.tex
+++ b/style.tex
@@ -106,11 +106,21 @@
 		Ligatures      = TeX
 	]%
 	{texgyrepagella-regular.otf}
+
+% Define a new 'widespaced' font that is used in section headings
+% or chapter titles. For backwards compatibility reasons this uses
+% the old calling convention \newfontfamily\fontname[<options>{font}
+% instead of the newer \newfontfamily\fontname{font}[<options>]
+\newfontfamily\widespaced[%
+	LetterSpace=15,%
+	WordSpace={1.25, 1.25, 1.25}%
+]{texgyrepagella-regular.otf}%
+
 \DeclareRobustCommand{\spacedallcaps}[1]{%
-	\oldstylenums{\addfontfeature{LetterSpace=15,WordSpace=1.25}{\MakeTextUppercase{#1}}}%
+	{\widespaced\oldstylenums{\MakeTextUppercase{#1}}}%
 }%
 \DeclareRobustCommand{\spacedlowsmallcaps}[1]{%
-	\oldstylenums{\textsc{\addfontfeature{LetterSpace=15,WordSpace=1.25}{\MakeTextLowercase{#1}}}}%
+	{\widespaced\oldstylenums{\textsc{\MakeTextLowercase{#1}}}}%
 }%
 \fi
 


### PR DESCRIPTION
Previously the \spacedallcaps and \spacedlowsmallcaps macros used
the \addfontfeature command to change the letterspace. In newer releases
of fontspec, this globally affects the current font.

See also: https://tex.stackexchange.com/questions/290937/new-version-of-fontspec-gives-wordspace-error/290947

To work around this issue we simply define a new font family that has
all the feature we want enabled.

Please note that this commit uses the calling convention

  \newfontfamily\fontname[<options>]{font}

instead of the newer

  \newfontfamily\fontname{font}[<options>]

to ensure compatibility with fontspec < 2.4.
