### PR TITLE
XeLaTeX: Do not use OldStyle numbers in main text

### DIFF
--- a/style.tex
+++ b/style.tex
@@ -102,7 +102,6 @@
 		BoldFont       = texgyrepagella-bold.otf,
 		ItalicFont     = texgyrepagella-italic.otf,
 		BoldItalicFont = texgyrepagella-bolditalic.otf,
-		Numbers        = {OldStyle},
 		Ligatures      = TeX
 	]%
 	{texgyrepagella-regular.otf}


### PR DESCRIPTION
OldStyle numbers make the text less readable. Only use them in headings.
